### PR TITLE
Feature: add pi agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ yoloai new task . --security gvisor
 | `gemini`   | Runs [Gemini](https://github.com/google-gemini) via API key or subscription credentials |
 | `aider`    | Runs [Aider](https://github.com/Aider-AI/aider) (your config is copied in) |
 | `opencode` | Runs [OpenCode](https://github.com/anomalyco/opencode) (your config is copied in) |
+| `pi`       | Runs [Pi Coding Agent](https://pi.dev) via API key or subscription credentials |
 | `shell`    | Runs a tmux shell with all agents credentials seeded |
 | `idle`     | Runs an idle process to allow MCP proxying |
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2,11 +2,15 @@
 package agent
 
 import (
+	_ "embed"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 )
+
+//go:embed pi-yoloai-status.ts
+var piYoloaiStatusExtension []byte
 
 // PromptMode determines how the agent receives its initial prompt.
 type PromptMode string
@@ -76,6 +80,12 @@ type Definition struct {
 	NetworkAllowlist  []string          // domains allowed when network-isolated
 	ContextFile       string            // filename in StateDir for sandbox context reference (e.g., "CLAUDE.md")
 	AgentFilesExclude []string          // glob patterns to skip when copying agent_files (string form)
+
+	// EmbeddedFiles maps target paths (relative to the agent's StateDir / the
+	// per-sandbox AgentRuntimeDir) to file contents that yoloAI writes at
+	// sandbox creation. Used to inject yoloAI-managed agent extensions such
+	// as pi's status hook.
+	EmbeddedFiles map[string][]byte
 
 	// ApplySettings patches the agent's settings map before it is written to disk.
 	// Called with the parsed settings map; mutates it in place.
@@ -272,6 +282,68 @@ var agents = map[string]*Definition{
 		NetworkAllowlist:  []string{"api.openai.com"},
 		AgentFilesExclude: []string{"auth.json", "sessions/"},
 	},
+	"pi": {
+		Name:           "pi",
+		Description:    "pi coding agent",
+		InteractiveCmd: "pi",
+		HeadlessCmd:    `pi "$PROMPT"`,
+		PromptMode:     PromptModeInteractive,
+		APIKeyEnvVars: []string{
+			"ANTHROPIC_API_KEY",                // Anthropic Claude API key
+			"ANTHROPIC_OAUTH_TOKEN",            // Anthropic OAuth token (alternative to API key)
+			"OPENAI_API_KEY",                   // OpenAI GPT API key
+			"AZURE_OPENAI_API_KEY",             // Azure OpenAI API key
+			"AZURE_OPENAI_BASE_URL",            // Azure OpenAI/Cognitive Services base URL (e.g. https://{resource}.openai.azure.com)
+			"AZURE_OPENAI_RESOURCE_NAME",       // Azure OpenAI resource name (alternative to base URL)
+			"AZURE_OPENAI_API_VERSION",         // Azure OpenAI API version (default: v1)
+			"AZURE_OPENAI_DEPLOYMENT_NAME_MAP", // Azure OpenAI model=deployment map (comma-separated)
+			"DEEPSEEK_API_KEY",                 // DeepSeek API key
+			"GEMINI_API_KEY",                   // Google Gemini API key
+			"GROQ_API_KEY",                     // Groq API key
+			"CEREBRAS_API_KEY",                 // Cerebras API key
+			"XAI_API_KEY",                      // XAI Grok API key
+			"FIREWORKS_API_KEY",                // Fireworks API key
+			"OPENROUTER_API_KEY",               // OpenRouter API key
+			"AI_GATEWAY_API_KEY",               // Vercel AI Gateway API key
+			"ZAI_API_KEY",                      // ZAI API key
+			"MISTRAL_API_KEY",                  // Mistral API key
+			"MINIMAX_API_KEY",                  // MiniMax API key
+			"OPENCODE_API_KEY",                 // OpenCode Zen/OpenCode Go API key
+			"KIMI_API_KEY",                     // Kimi For Coding API key
+			"CLOUDFLARE_API_KEY",               // Cloudflare API token (Workers AI)
+			"CLOUDFLARE_ACCOUNT_ID",            // Cloudflare account id (required for Workers AI)
+			"AWS_PROFILE",                      // AWS profile for Amazon Bedrock
+			"AWS_ACCESS_KEY_ID",                // AWS access key for Amazon Bedrock
+			"AWS_SECRET_ACCESS_KEY",            // AWS secret key for Amazon Bedrock
+			"AWS_BEARER_TOKEN_BEDROCK",         // Bedrock API key (bearer token)
+			"AWS_REGION",                       // AWS region for Amazon Bedrock (e.g., us-east-1)
+			"PI_CODING_AGENT_DIR",              // Session storage directory (default: ~/.pi/agent)
+			"PI_PACKAGE_DIR",                   // Override package directory (for Nix/Guix store paths)
+			"PI_OFFLINE",                       // Disable startup network operations when set to 1/true/yes
+			"PI_TELEMETRY",                     // Override install telemetry when set to 1/true/yes or 0/false/no
+			"PI_SHARE_VIEWER_URL",              // Base URL for /share command (default: https://pi.dev/session/)
+			"PI_AI_ANTIGRAVITY_VERSION",        // Override Antigravity User-Agent version (e.g., 1.23.0)
+		},
+		SeedFiles: []SeedFile{
+			{HostPath: "~/.pi/agent/auth.json", TargetPath: "agent/auth.json", AuthOnly: true},
+			{HostPath: "~/.pi/agent/models.json", TargetPath: "agent/models.json"},
+			{HostPath: "~/.pi/agent/settings.json", TargetPath: "agent/settings.json"},
+		},
+		StateDir:       "/home/yoloai/.pi/",
+		SubmitSequence: "Enter",
+		StartupDelay:   3 * time.Second,
+		Idle: IdleSupport{
+			Hook:            true,
+			WchanApplicable: true,
+		},
+		ModelFlag:         "--model",
+		NetworkAllowlist:  []string{},
+		ContextFile:       "agent/AGENTS.md",
+		AgentFilesExclude: []string{"auth.json", "models.json", "settings.json", "AGENTS.md", "sessions/", "extensions/yoloai-status.ts"},
+		EmbeddedFiles: map[string][]byte{
+			"agent/extensions/yoloai-status.ts": piYoloaiStatusExtension,
+		},
+	},
 	"test": {
 		Name:           "test",
 		Description:    "Bash shell for testing and development",
@@ -382,7 +454,7 @@ func buildShellAgent() *Definition {
 	return &Definition{
 		Name:             "shell",
 		Description:      "Bash shell with all agents' credentials seeded",
-		InteractiveCmd:   `bash -c 'printf "\n  yoloai shell — launch any agent with yolo-<name>\n  Available: yolo-aider  yolo-claude  yolo-codex  yolo-gemini  yolo-opencode\n\n"; exec bash'`,
+		InteractiveCmd:   `bash -c 'printf "\n  yoloai shell — launch any agent with yolo-<name>\n  Available: yolo-aider  yolo-claude  yolo-codex  yolo-gemini  yolo-opencode  yolo-pi\n\n"; exec bash'`,
 		HeadlessCmd:      `sh -c "PROMPT"`,
 		PromptMode:       PromptModeHeadless,
 		APIKeyEnvVars:    apiKeys,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -170,9 +170,50 @@ func TestGetAgent_Codex(t *testing.T) {
 	assert.Equal(t, []string{"api.openai.com"}, def.NetworkAllowlist)
 }
 
+func TestGetAgent_Pi(t *testing.T) {
+	def := GetAgent("pi")
+	require.NotNil(t, def)
+
+	assert.Equal(t, "pi", def.Name)
+	assert.NotEmpty(t, def.Description)
+	assert.Equal(t, "pi", def.InteractiveCmd)
+	assert.Contains(t, def.HeadlessCmd, `pi "$PROMPT"`)
+	assert.Equal(t, PromptModeInteractive, def.PromptMode)
+	assert.Contains(t, def.APIKeyEnvVars, "ANTHROPIC_API_KEY")
+	assert.Contains(t, def.APIKeyEnvVars, "OPENAI_API_KEY")
+	assert.Contains(t, def.APIKeyEnvVars, "GEMINI_API_KEY")
+	assert.Contains(t, def.APIKeyEnvVars, "DEEPSEEK_API_KEY")
+	assert.Contains(t, def.APIKeyEnvVars, "GROQ_API_KEY")
+	assert.Contains(t, def.APIKeyEnvVars, "XAI_API_KEY")
+	require.Len(t, def.SeedFiles, 3)
+	assert.Equal(t, "~/.pi/agent/auth.json", def.SeedFiles[0].HostPath)
+	assert.Equal(t, "agent/auth.json", def.SeedFiles[0].TargetPath)
+	assert.True(t, def.SeedFiles[0].AuthOnly)
+	assert.Equal(t, "~/.pi/agent/models.json", def.SeedFiles[1].HostPath)
+	assert.Equal(t, "agent/models.json", def.SeedFiles[1].TargetPath)
+	assert.False(t, def.SeedFiles[1].AuthOnly)
+	assert.Equal(t, "~/.pi/agent/settings.json", def.SeedFiles[2].HostPath)
+	assert.Equal(t, "agent/settings.json", def.SeedFiles[2].TargetPath)
+	assert.False(t, def.SeedFiles[2].AuthOnly)
+	assert.Equal(t, "/home/yoloai/.pi/", def.StateDir)
+	assert.Equal(t, "Enter", def.SubmitSequence)
+	assert.Equal(t, 3*time.Second, def.StartupDelay)
+	assert.Equal(t, "--model", def.ModelFlag)
+	assert.Empty(t, def.Idle.ReadyPattern)
+	assert.False(t, def.Idle.ContextSignal)
+	assert.True(t, def.Idle.Hook)
+	assert.True(t, def.Idle.WchanApplicable)
+	assert.Equal(t, "agent/AGENTS.md", def.ContextFile)
+	require.NotNil(t, def.EmbeddedFiles)
+	ext, ok := def.EmbeddedFiles["agent/extensions/yoloai-status.ts"]
+	require.True(t, ok, "pi should embed agent/extensions/yoloai-status.ts")
+	assert.Contains(t, string(ext), "agent_start")
+	assert.Contains(t, string(ext), "agent_end")
+}
+
 func TestAllAgentNames(t *testing.T) {
 	names := AllAgentNames()
-	assert.Equal(t, []string{"aider", "claude", "codex", "gemini", "idle", "opencode", "shell", "test"}, names)
+	assert.Equal(t, []string{"aider", "claude", "codex", "gemini", "idle", "opencode", "pi", "shell", "test"}, names)
 }
 
 func TestGetAgent_Test(t *testing.T) {
@@ -197,7 +238,7 @@ func TestGetAgent_Test(t *testing.T) {
 
 func TestRealAgents(t *testing.T) {
 	names := RealAgents()
-	assert.Equal(t, []string{"aider", "claude", "codex", "gemini", "opencode"}, names)
+	assert.Equal(t, []string{"aider", "claude", "codex", "gemini", "opencode", "pi"}, names)
 }
 
 func TestGetAgent_Shell(t *testing.T) {
@@ -211,6 +252,7 @@ func TestGetAgent_Shell(t *testing.T) {
 	assert.Contains(t, def.InteractiveCmd, "yolo-gemini")
 	assert.Contains(t, def.InteractiveCmd, "yolo-aider")
 	assert.Contains(t, def.InteractiveCmd, "yolo-opencode")
+	assert.Contains(t, def.InteractiveCmd, "yolo-pi")
 	assert.Contains(t, def.HeadlessCmd, "sh -c")
 	assert.Equal(t, PromptModeHeadless, def.PromptMode)
 	assert.Equal(t, "", def.StateDir)
@@ -255,6 +297,9 @@ func TestGetAgent_Shell(t *testing.T) {
 	assert.Contains(t, targetPaths, ".config/github-copilot/hosts.json") // was already HomeDir, unchanged
 	assert.Contains(t, targetPaths, ".config/github-copilot/apps.json")  // was already HomeDir, unchanged
 	assert.Contains(t, targetPaths, ".config/opencode/.opencode.json")   // was already HomeDir, unchanged
+	assert.Contains(t, targetPaths, ".pi/agent/auth.json")
+	assert.Contains(t, targetPaths, ".pi/agent/models.json")
+	assert.Contains(t, targetPaths, ".pi/agent/settings.json")
 
 	// Each seed file should have OwnerAPIKeys set
 	for _, sf := range def.SeedFiles {
@@ -276,6 +321,7 @@ func TestStateRelPath(t *testing.T) {
 		{"gemini", ".gemini"},
 		{"codex", ".codex"},
 		{"opencode", ".local/share/opencode"},
+		{"pi", ".pi"},
 		{"aider", ""}, // no StateDir
 		{"test", ""},  // no StateDir
 		{"shell", ""}, // no StateDir
@@ -364,7 +410,7 @@ func TestApplySettings_GeminiPreservesExistingSecurityFields(t *testing.T) {
 }
 
 func TestApplySettings_OtherAgentsNil(t *testing.T) {
-	for _, name := range []string{"aider", "codex", "opencode", "test", "idle"} {
+	for _, name := range []string{"aider", "codex", "opencode", "pi", "test", "idle"} {
 		def := GetAgent(name)
 		require.NotNil(t, def, "agent %q should exist", name)
 		assert.Nil(t, def.ApplySettings, "agent %q should have nil ApplySettings", name)
@@ -374,7 +420,7 @@ func TestApplySettings_OtherAgentsNil(t *testing.T) {
 func TestShortLivedOAuthWarning(t *testing.T) {
 	assert.True(t, GetAgent("claude").ShortLivedOAuthWarning, "claude should have ShortLivedOAuthWarning=true")
 
-	for _, name := range []string{"aider", "gemini", "codex", "opencode", "test", "idle", "shell"} {
+	for _, name := range []string{"aider", "gemini", "codex", "opencode", "pi", "test", "idle", "shell"} {
 		def := GetAgent(name)
 		require.NotNil(t, def, "agent %q should exist", name)
 		assert.False(t, def.ShortLivedOAuthWarning, "agent %q should have ShortLivedOAuthWarning=false", name)
@@ -384,7 +430,7 @@ func TestShortLivedOAuthWarning(t *testing.T) {
 func TestSeedsAllAgents(t *testing.T) {
 	assert.True(t, GetAgent("shell").SeedsAllAgents, "shell should have SeedsAllAgents=true")
 
-	for _, name := range []string{"aider", "claude", "gemini", "codex", "opencode", "test", "idle"} {
+	for _, name := range []string{"aider", "claude", "gemini", "codex", "opencode", "pi", "test", "idle"} {
 		def := GetAgent(name)
 		require.NotNil(t, def, "agent %q should exist", name)
 		assert.False(t, def.SeedsAllAgents, "agent %q should have SeedsAllAgents=false", name)

--- a/agent/pi-yoloai-status.ts
+++ b/agent/pi-yoloai-status.ts
@@ -1,0 +1,49 @@
+// yoloAI status hook for pi.
+//
+// Writes ${YOLOAI_DIR}/agent-status.json on agent_start (active) / agent_end
+// (idle) so the in-container status monitor's HookDetector can report idle
+// with high confidence. Mirrors the Claude Code Stop/PreToolUse hook pattern.
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const YOLOAI_DIR = process.env.YOLOAI_DIR ?? "/yoloai";
+const STATUS_FILE = `${YOLOAI_DIR}/agent-status.json`;
+const HOOKS_LOG = `${YOLOAI_DIR}/logs/agent-hooks.jsonl`;
+
+function writeStatus(status: "active" | "idle"): void {
+	const ts = Math.floor(Date.now() / 1000);
+	try {
+		writeFileSync(
+			STATUS_FILE,
+			JSON.stringify({ status, exit_code: null, timestamp: ts }),
+		);
+	} catch {
+		// best-effort; outside a yoloAI sandbox this directory may not exist
+	}
+	try {
+		mkdirSync(dirname(HOOKS_LOG), { recursive: true });
+		appendFileSync(
+			HOOKS_LOG,
+			`${JSON.stringify({
+				ts: new Date().toISOString(),
+				level: "info",
+				event: `hook.${status}`,
+				msg: `pi extension: ${status}`,
+				status,
+			})}\n`,
+		);
+	} catch {
+		// best-effort
+	}
+}
+
+export default function (pi: ExtensionAPI): void {
+	pi.on("agent_start", () => {
+		writeStatus("active");
+	});
+	pi.on("agent_end", () => {
+		writeStatus("idle");
+	});
+}

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -10,7 +10,7 @@ import "strings"
 const DefaultConfigYAML = `# --- Agent ---
 
 # Agent to launch inside the sandbox.
-# Valid values: aider, claude, codex, gemini, opencode
+# Valid values: aider, claude, codex, gemini, opencode, pi
 # CLI --agent overrides.
 agent: claude
 

--- a/docs/dev/research/competitors.md
+++ b/docs/dev/research/competitors.md
@@ -361,7 +361,7 @@ Developers already using or interested in the Pinix platform who want an intelli
 |--------|-----------|--------|
 | Core purpose | General-purpose AI agent runtime | Sandboxed AI coding agent runner |
 | Sandboxing model | Platform-provided (Pinix BoxLite micro-VMs) — incidental | Intentional isolation (Docker / Tart / Seatbelt) |
-| Supported agents | Custom agent (OpenRouter LLM) | Claude Code, Gemini CLI, Codex, Aider, OpenCode |
+| Supported agents | Custom agent (OpenRouter LLM) | Claude Code, Gemini CLI, Codex, Aider, OpenCode, Pi |
 | Copy/diff/apply workflow | No | Yes (core differentiator) |
 | User reviews changes before apply | No | Yes |
 | Persistent sandbox state | Yes (SQLite, `data/` dir survives upgrades) | Yes (`~/.yoloai/sandboxes/<name>/`) |

--- a/internal/cli/help/flags.md
+++ b/internal/cli/help/flags.md
@@ -8,7 +8,7 @@ GLOBAL FLAGS
 
 CREATING SANDBOXES (yoloai new)
 
-  --agent <name>      Agent to use (claude, gemini, etc.)
+  --agent <name>      Agent to use (aider, claude, codex, gemini, opencode, pi, etc.)
   --model, -m <name>  Model name or alias
   --backend <name>    Runtime backend (docker, tart, seatbelt)
   --prompt, -p <text> Prompt for headless mode

--- a/runtime/docker/resources/Dockerfile
+++ b/runtime/docker/resources/Dockerfile
@@ -80,7 +80,8 @@ ENV DISABLE_INSTALLATION_CHECKS=1
 RUN npm install -g @anthropic-ai/claude-code \
     && npm install -g @google/gemini-cli \
     && npm install -g @openai/codex \
-    && npm install -g opencode-ai
+    && npm install -g opencode-ai \
+    && npm install -g @mariozechner/pi-coding-agent
 # hadolint ignore=DL3013
 RUN pip install --break-system-packages --no-cache-dir aider-chat
 
@@ -90,7 +91,8 @@ RUN printf '#!/bin/sh\nexec aider --yes-always "$@"\n' > /usr/local/bin/yolo-aid
     && printf '#!/bin/sh\nexec codex --dangerously-bypass-approvals-and-sandbox "$@"\n' > /usr/local/bin/yolo-codex \
     && printf '#!/bin/sh\nexec gemini --yolo "$@"\n' > /usr/local/bin/yolo-gemini \
     && printf '#!/bin/sh\nexec opencode "$@"\n' > /usr/local/bin/yolo-opencode \
-    && chmod +x /usr/local/bin/yolo-aider /usr/local/bin/yolo-claude /usr/local/bin/yolo-codex /usr/local/bin/yolo-gemini /usr/local/bin/yolo-opencode
+    && printf '#!/bin/sh\nexec pi "$@"\n' > /usr/local/bin/yolo-pi \
+    && chmod +x /usr/local/bin/yolo-aider /usr/local/bin/yolo-claude /usr/local/bin/yolo-codex /usr/local/bin/yolo-gemini /usr/local/bin/yolo-opencode /usr/local/bin/yolo-pi
 
 # gosu for dropping privileges
 ARG GOSU_VERSION=1.17
@@ -113,6 +115,7 @@ RUN mkdir -p \
         /home/yoloai/.claude \
         /home/yoloai/.gemini \
         /home/yoloai/.codex \
+        /home/yoloai/.pi/agent \
         /home/yoloai/.local/share/opencode \
         /home/yoloai/.config/github-copilot \
         /home/yoloai/.config/opencode \

--- a/sandbox/context.go
+++ b/sandbox/context.go
@@ -144,6 +144,19 @@ func WriteContextFiles(sandboxDir string, meta *Meta, agentDef *agent.Definition
 		return fmt.Errorf("write context.md: %w", err)
 	}
 
+	// Embedded agent files (e.g. pi's status hook extension). Paths are
+	// relative to AgentRuntimeDir, which is bind-mounted at the agent's
+	// StateDir inside the container.
+	for relPath, fileContent := range agentDef.EmbeddedFiles {
+		targetPath := filepath.Join(sandboxDir, AgentRuntimeDir, relPath)
+		if err := fileutil.MkdirAll(filepath.Dir(targetPath), 0750); err != nil {
+			return fmt.Errorf("create dir for embedded file %s: %w", relPath, err)
+		}
+		if err := fileutil.WriteFile(targetPath, fileContent, 0600); err != nil {
+			return fmt.Errorf("write embedded file %s: %w", relPath, err)
+		}
+	}
+
 	// Write full context inline into the agent's native instruction file
 	if agentDef.ContextFile != "" && agentDef.StateDir != "" {
 		refPath := filepath.Join(sandboxDir, AgentRuntimeDir, agentDef.ContextFile)

--- a/sandbox/context_test.go
+++ b/sandbox/context_test.go
@@ -237,6 +237,41 @@ func TestWriteContextFiles_WritesContextAndRef(t *testing.T) {
 	}
 }
 
+func TestWriteContextFiles_WritesEmbeddedFiles(t *testing.T) {
+	sandboxDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(sandboxDir, AgentRuntimeDir), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := &Meta{
+		Workdir: WorkdirMeta{
+			HostPath:  "/project",
+			MountPath: "/project",
+			Mode:      "copy",
+		},
+	}
+	agentDef := &agent.Definition{
+		Name:     "pi",
+		StateDir: "/home/yoloai/.pi/",
+		EmbeddedFiles: map[string][]byte{
+			"agent/extensions/yoloai-status.ts": []byte("hello world"),
+		},
+	}
+
+	if err := WriteContextFiles(sandboxDir, meta, agentDef); err != nil {
+		t.Fatalf("WriteContextFiles: %v", err)
+	}
+
+	embeddedPath := filepath.Join(sandboxDir, AgentRuntimeDir, "agent", "extensions", "yoloai-status.ts")
+	data, err := os.ReadFile(embeddedPath) //nolint:gosec // G304: test helper path
+	if err != nil {
+		t.Fatalf("read embedded file: %v", err)
+	}
+	if string(data) != "hello world" {
+		t.Errorf("embedded file content mismatch: got %q", string(data))
+	}
+}
+
 func TestWriteContextFiles_NoRefWhenEmpty(t *testing.T) {
 	sandboxDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(sandboxDir, AgentRuntimeDir), 0750); err != nil {


### PR DESCRIPTION
Pi is an minimal agent harness written mostly in typescript: https://pi.dev/

This commit adds support for pi to yoloai.

```
yoloai new --agent pi .
```

It seemed not reliably possible to pin down a ready/idle pattern for pi (we started with an empty string, but that would always yield 'active' in yoloai ls). The pi agent has support for hooking into lifecycle events and it is very open to extensions. We hence add "agent/pi-yoloai-status.ts" extension, which syncs a file with the agent status. The extension script is embedded into agent/agent.go and will be written into agent runtime dir, where pi will pick it up. In end-to-end manual testing, this solves the idle signal problem reliably.

Caveat: Adding this agent required to add "EmbeddedFiles" field to the agent definition and "pi-yoloai-status.ts" to the agent package.

AI disclosure: Co-written by claude opus 4.7 by looking at both the yoloai and badlogic/pi-mono repositories.

----

Note: this is a first draft; especially adding `agent/pi-yoloai-status.ts` feels a bit much (could be just inlined as a string). 