### PR TITLE
Fix/apple container builds dockerfiles named in profiles

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -895,6 +895,7 @@ Isolation modes are silently ignored on non-container backends (tart, seatbelt).
 - **Network isolation works** the same as on Linux — the in-VM Linux kernel enforces the `--network-isolated` allowlist.
 - **No suspend/resume and no VS Code "Attach to Running Container".** `container` has no checkpoint or docker-compat API; `exec`-based attach (`yoloai attach`) works normally.
 - **Memory is not released back to the host** until the VM stops (virtio-balloon) — minor for ephemeral sandboxes.
+- **Profile Dockerfiles are built via Apple's own builder** (`container build`, same as `docker build`/`podman build`) — a profile's `yoloai-<profile>` image is built and cached automatically, no manual step needed. One gap versus Docker/Podman: no `--secret` build-secret support, so an auto-detected secret (e.g. `~/.npmrc`) is reported and dropped rather than passed into the build.
 
 **`container-privileged` — Docker-in-Docker and Compose:**
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -895,7 +895,7 @@ Isolation modes are silently ignored on non-container backends (tart, seatbelt).
 - **Network isolation works** the same as on Linux — the in-VM Linux kernel enforces the `--network-isolated` allowlist.
 - **No suspend/resume and no VS Code "Attach to Running Container".** `container` has no checkpoint or docker-compat API; `exec`-based attach (`yoloai attach`) works normally.
 - **Memory is not released back to the host** until the VM stops (virtio-balloon) — minor for ephemeral sandboxes.
-- **Profile Dockerfiles are built via Apple's own builder** (`container build`, same as `docker build`/`podman build`) — a profile's `yoloai-<principal>-<profile>` image is built and cached automatically, no manual step needed. One gap versus Docker/Podman: no `--secret` build-secret support, so an auto-detected secret (e.g. `~/.npmrc`) is reported and dropped rather than passed into the build.
+- **Profile Dockerfiles are built via Apple's own builder** (`container build`, same as `docker build`/`podman build`) — a profile's `yoloai-cli-<profile>` image is built and cached automatically, no manual step needed. One gap versus Docker/Podman: no `--secret` build-secret support, so an auto-detected secret (e.g. `~/.npmrc`) is reported and dropped rather than passed into the build.
 
 **`container-privileged` — Docker-in-Docker and Compose:**
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -895,7 +895,7 @@ Isolation modes are silently ignored on non-container backends (tart, seatbelt).
 - **Network isolation works** the same as on Linux — the in-VM Linux kernel enforces the `--network-isolated` allowlist.
 - **No suspend/resume and no VS Code "Attach to Running Container".** `container` has no checkpoint or docker-compat API; `exec`-based attach (`yoloai attach`) works normally.
 - **Memory is not released back to the host** until the VM stops (virtio-balloon) — minor for ephemeral sandboxes.
-- **Profile Dockerfiles are built via Apple's own builder** (`container build`, same as `docker build`/`podman build`) — a profile's `yoloai-<profile>` image is built and cached automatically, no manual step needed. One gap versus Docker/Podman: no `--secret` build-secret support, so an auto-detected secret (e.g. `~/.npmrc`) is reported and dropped rather than passed into the build.
+- **Profile Dockerfiles are built via Apple's own builder** (`container build`, same as `docker build`/`podman build`) — a profile's `yoloai-<principal>-<profile>` image is built and cached automatically, no manual step needed. One gap versus Docker/Podman: no `--secret` build-secret support, so an auto-detected secret (e.g. `~/.npmrc`) is reported and dropped rather than passed into the build.
 
 **`container-privileged` — Docker-in-Docker and Compose:**
 

--- a/docs/contributors/design/config.md
+++ b/docs/contributors/design/config.md
@@ -176,7 +176,7 @@ Profiles live in `~/.yoloai/profiles/<name>/` and are always selected explicitly
 **Backend handling:**
 - `os` — optional. Selects the guest OS for the sandbox. Valid values: `linux` (default), `mac`. `linux` is the default and requires no special hardware. `mac` requires a macOS host; the backend depends on `isolation`: `container` uses Seatbelt, `vm` uses Tart. Fails loudly on non-macOS hosts or if the required backend is not installed. CLI `--os` overrides.
 - `container_backend` — optional preference. Only meaningful for `--isolation container` or `container-enhanced`; ignored for `vm`, `vm-enhanced`, and `--os mac`.
-- `Dockerfile` — optional. Used with Docker and Podman backends to build a `yoloai-cli-<profile>` image. Must use `FROM yoloai-base`. Ignored with Tart and Seatbelt backends. When absent, Docker/Podman backends use `yoloai-base`.
+- `Dockerfile` — optional. Used with Docker, Podman, and Apple `container` backends to build a `yoloai-<profile>` image (`container build`, mirroring `docker build`/`podman build`). Must use `FROM yoloai-base`. Ignored with Tart and Seatbelt backends (no OCI image concept). When absent, image-based backends use `yoloai-base`. The Apple backend has no `--secret` build-secret support (unlike Docker/Podman's BuildKit invocation): any auto-detected secrets (e.g. `~/.npmrc`) are reported and dropped rather than passed through.
 - `tart.image` — optional. Used only with the Tart backend. Ignored with other backends.
 
 **Sandbox metadata:** When a profile is used, `environment.json` records the profile name and the resolved image ref. Lifecycle commands use the stored image ref — profile changes only take effect on new sandboxes.

--- a/docs/contributors/design/config.md
+++ b/docs/contributors/design/config.md
@@ -183,7 +183,11 @@ Profiles live in `~/.yoloai/profiles/<name>/` and are always selected explicitly
 
 **Profile image building:** The sandbox manager calls `Runtime.EnsureImage()` for the base image, then uses container-backend build logic for profile images when Docker, Podman, or Apple `container` is active and the profile has a Dockerfile. Tart and Seatbelt skip profile image building.
 
-**Profile image staleness:** A profile image is considered stale when: (a) it doesn't exist, (b) the profile's Dockerfile has changed since last build (checksum-tracked), or (c) `yoloai-base` has been rebuilt since the profile image was last built. Stale images are automatically rebuilt during `yoloai new --profile`.
+**Profile image staleness:** A profile image is considered stale when (a) this backend has no recorded build for it, (b) the profile's Dockerfile has changed since that build, or (c) the parent profile was rebuilt more recently. Stale images are automatically rebuilt during `yoloai new --profile`.
+
+The record is a checksum marker in the profile directory, **keyed by backend** — `.last-build-checksum-<backendKey>` (DF150). The profile directory is shared across backends but their image stores are not, so each backend's freshness is tracked independently; a profile can be current for docker and stale for apple at the same time.
+
+**Nothing checks whether the image actually exists.** Staleness is inferred entirely from the marker, so a marker that outlives its image — deleted by hand, pruned, or written by a backend that turned out to address a different daemon — reads as "fresh" and the build is skipped. The failure surfaces later and elsewhere, as a pull of a local-only tag. See [DF152](findings-unresolved.md) for the daemon-switch case and [DF154](findings-unresolved.md) for the missing existence check.
 
 **`config.yaml` format:**
 

--- a/docs/contributors/design/config.md
+++ b/docs/contributors/design/config.md
@@ -176,12 +176,12 @@ Profiles live in `~/.yoloai/profiles/<name>/` and are always selected explicitly
 **Backend handling:**
 - `os` — optional. Selects the guest OS for the sandbox. Valid values: `linux` (default), `mac`. `linux` is the default and requires no special hardware. `mac` requires a macOS host; the backend depends on `isolation`: `container` uses Seatbelt, `vm` uses Tart. Fails loudly on non-macOS hosts or if the required backend is not installed. CLI `--os` overrides.
 - `container_backend` — optional preference. Only meaningful for `--isolation container` or `container-enhanced`; ignored for `vm`, `vm-enhanced`, and `--os mac`.
-- `Dockerfile` — optional. Used with Docker, Podman, and Apple `container` backends to build a `yoloai-<profile>` image (`container build`, mirroring `docker build`/`podman build`). Must use `FROM yoloai-base`. Ignored with Tart and Seatbelt backends (no OCI image concept). When absent, image-based backends use `yoloai-base`. The Apple backend has no `--secret` build-secret support (unlike Docker/Podman's BuildKit invocation): any auto-detected secrets (e.g. `~/.npmrc`) are reported and dropped rather than passed through.
+- `Dockerfile` — optional. Used with Docker, Podman, and Apple `container` backends to build a `yoloai-<principal>-<profile>` image (`container build`, mirroring `docker build`/`podman build`). Must use `FROM yoloai-base`. Ignored with Tart and Seatbelt backends (no OCI image concept). When absent, image-based backends use `yoloai-base`. The Apple backend has no `--secret` build-secret support (unlike Docker/Podman's BuildKit invocation): any auto-detected secrets (e.g. `~/.npmrc`) are reported and dropped rather than passed through.
 - `tart.image` — optional. Used only with the Tart backend. Ignored with other backends.
 
 **Sandbox metadata:** When a profile is used, `environment.json` records the profile name and the resolved image ref. Lifecycle commands use the stored image ref — profile changes only take effect on new sandboxes.
 
-**Profile image building:** The sandbox manager calls `Runtime.EnsureImage()` for the base image, then uses container-backend build logic for profile images when Docker or Podman is active and the profile has a Dockerfile. Tart and Seatbelt skip profile image building.
+**Profile image building:** The sandbox manager calls `Runtime.EnsureImage()` for the base image, then uses container-backend build logic for profile images when Docker, Podman, or Apple `container` is active and the profile has a Dockerfile. Tart and Seatbelt skip profile image building.
 
 **Profile image staleness:** A profile image is considered stale when: (a) it doesn't exist, (b) the profile's Dockerfile has changed since last build (checksum-tracked), or (c) `yoloai-base` has been rebuilt since the profile image was last built. Stale images are automatically rebuilt during `yoloai new --profile`.
 

--- a/docs/contributors/design/findings-unresolved.md
+++ b/docs/contributors/design/findings-unresolved.md
@@ -638,7 +638,7 @@ is worse than none because it also supplies the confidence.
   on that profile runs `yoloai-base` unmodified, with no error). Same class as the pre-fix apple
   defect this PR closes, and the same class DF150/DF152 cover for the backends that do implement
   the interface.
-- **Disposition:** FILED, not fixed — explicitly out of scope for this PR per the owner's review.
+- **Disposition:** PARKED — explicitly out of scope for the PR that found it, per the owner's review.
 - **Description:** `runtime.ProfileImageBuilder` (`runtime/runtime_optional.go`) is implemented by
   docker, podman (via embedding), and now apple. containerd has its own OCI image store — the same
   shape of backend docker/podman/apple are — but declares no
@@ -665,6 +665,17 @@ is worse than none because it also supplies the confidence.
   `runtime/containerd/containerd.go:106-111` (missing assertion); `runtime/docker/build.go`
   (`ProfileImageNeedsBuild`, `RecordProfileBuildChecksum`, the shared scheme to reuse); `runtime/apple/apple.go`
   (the sibling fix this PR made for apple). Related: DF150, DF151, DF152.
+
+### DF154 — profile-image staleness never checks that the image exists, so a marker outliving its image skips the build
+
+- **Discovered:** 2026-07-29 · **Workstream:** PR #44 follow-up
+- **Severity:** MEDIUM (silent skip then a confusing failure — `run` attempts to pull a local-only tag — with no path back except deleting the marker by hand or passing `--force`)
+- **Disposition:** PARKED
+- **Description:** `EnsureProfileImage` (`internal/orchestrator/profiles/profile_build.go`) gates the build solely on `force || builder.ProfileImageNeedsBuild(profileDir, prevDir)`, and `ProfileImageNeedsBuild` reads only the checksum marker on disk. **No code anywhere asks the backend whether the image is present.** So the marker is not evidence that the image exists; it is evidence that a build once ran. Delete the image by hand, prune it, or write the marker from a backend that turned out to address a different store, and yoloAI reads "fresh", skips the build, and fails later at `run` with a pull of a tag no local store has.
+- **This is the root the other two findings sit on.** DF150 (marker not keyed by backend) and DF152 (backend name is a poor proxy for a store on docker) are both about the marker *lying about which store it describes*. An existence check makes that class self-healing rather than fatal: a wrong-store marker would cost one unnecessary rebuild instead of a failed run. Worth weighing that against fixing each proxy problem separately — this is the cheaper invariant, and it is the one the design doc has claimed for a long time. `config.md`'s staleness paragraph listed "it doesn't exist" as condition (a) until 2026-07-29; it was never implemented, and the doc has been corrected rather than the code.
+- **Why not just fix it here:** the check needs a backend round-trip (an image inspect/exists call) on a path that is currently pure file I/O, so it wants either a new optional method on `ProfileImageBuilder` or a widening of `ProfileImageNeedsBuild`'s signature — the same interface change DF152 needs, and best done once, together.
+- **Cost note:** an existence probe runs on every `yoloai new --profile`, so it should be cheap and non-fatal on error (a probe that fails should fall back to the marker, never block the launch).
+- **Pointer:** `internal/orchestrator/profiles/profile_build.go` (`EnsureProfileImage`, the gate); `runtime/docker/build.go` (`ProfileImageNeedsBuild` — marker-only); `runtime/runtime_optional.go` (`ProfileImageBuilder`). Related: DF150 (resolved), DF152, DF153.
 
 ## Policy origin
 

--- a/docs/contributors/design/findings-unresolved.md
+++ b/docs/contributors/design/findings-unresolved.md
@@ -631,6 +631,41 @@ is worse than none because it also supplies the confidence.
   + `runtime/seatbelt/profile.go:193-199` (the rw share/grant); `internal/orchestrator/engine_network.go:62,84`;
   `runtime/seatbelt/seatbelt.go:827-831`; `internal/orchestrator/lifecycle/restart.go:163,180-208`. Related: DF136.
 
+### DF153 — containerd is image-based but does not implement `ProfileImageBuilder`, so profile Dockerfiles are silently skipped there too
+
+- **Discovered:** 2026-07-27 · **Workstream:** PR #44 review (first external contribution)
+- **Severity:** MEDIUM (silent skip — a profile with a Dockerfile builds nothing and every sandbox
+  on that profile runs `yoloai-base` unmodified, with no error). Same class as the pre-fix apple
+  defect this PR closes, and the same class DF150/DF152 cover for the backends that do implement
+  the interface.
+- **Disposition:** FILED, not fixed — explicitly out of scope for this PR per the owner's review.
+- **Description:** `runtime.ProfileImageBuilder` (`runtime/runtime_optional.go`) is implemented by
+  docker, podman (via embedding), and now apple. containerd has its own OCI image store — the same
+  shape of backend docker/podman/apple are — but declares no
+  `var _ runtime.ProfileImageBuilder = (*Runtime)(nil)` and has no `BuildProfileImage`/
+  `ProfileImageNeedsBuild`/`RecordProfileBuildChecksum` methods at all. `ProfileImageBuilderOf`
+  (`runtime_optional.go`) falls through its `ok` branch for containerd exactly as it did for apple
+  before this PR, so a profile's Dockerfile is silently ignored rather than built.
+- **Root cause, and why the interface being back in `runtime_optional.go` matters:**
+  `ProfileImageBuilder` used to live in `internal/orchestrator/profiles`, where no backend in the
+  public runtime tree could compile-time assert it — that's how apple came to be missing it
+  unnoticed, and it's why containerd is missing it unnoticed now. Every other optional capability
+  lives in `runtime/runtime_optional.go` with the `var _ runtime.CachePruner = (*Runtime)(nil)`
+  idiom (`runtime/podman/podman.go:101`); moving `ProfileImageBuilder` there (done in this PR's
+  rebase, DF151) doesn't retrofit a missing assertion into containerd — that stays a per-backend
+  choice — but it does mean the next audit of "which backends assert which optional interfaces"
+  will actually surface the gap instead of it hiding behind a package nothing sweeps.
+- **Remedy sketch:** implement `BuildProfileImage`/`ProfileImageNeedsBuild`/
+  `RecordProfileBuildChecksum` on `runtime/containerd.Runtime`, keyed by backend `"containerd"`
+  through the shared `docker.ProfileImageNeedsBuild`/`docker.RecordProfileBuildChecksum` scheme
+  (DF150), and add the compile-time assertion. containerd's `CreateBuildContext`/build-context
+  materialization needs the same absolute-directory care apple's fix pinned (AC1) if containerd's
+  build command takes a directory context rather than a stdin tar.
+- **Pointer:** `runtime/runtime_optional.go` (`ProfileImageBuilder`, `ProfileImageBuilderOf`);
+  `runtime/containerd/containerd.go:106-111` (missing assertion); `runtime/docker/build.go`
+  (`ProfileImageNeedsBuild`, `RecordProfileBuildChecksum`, the shared scheme to reuse); `runtime/apple/apple.go`
+  (the sibling fix this PR made for apple). Related: DF150, DF151, DF152.
+
 ## Policy origin
 
 Established in [architecture-remediation.md](../archive/plans/architecture-remediation.md) and inherited by [layering-refactor.md](../archive/plans/layering-refactor.md).

--- a/runtime/apple/apple.go
+++ b/runtime/apple/apple.go
@@ -501,7 +501,7 @@ func (r *Runtime) BuildProfileImage(ctx context.Context, sourceDir string, tag s
 	}
 	logger.Debug("building profile image via container build", "tag", tag, "sourceDir", sourceDir, "context", dir)
 
-	cmd := sysexec.CommandContext(ctx, r.execEnv, r.containerBin, "build", "-t", tag, dir)
+	cmd := sysexec.CommandContext(ctx, buildEnv.Env().EnvForAppleContainer(), r.containerBin, "build", "-t", tag, dir)
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Run(); err != nil {

--- a/runtime/apple/apple.go
+++ b/runtime/apple/apple.go
@@ -472,11 +472,61 @@ func (r *Runtime) buildBaseImage(ctx context.Context, layout config.Layout, outp
 	return nil
 }
 
-// Prune sweeps orphaned apple containers — instances this principal created that
-// no longer correspond to a known sandbox. Mirrors the docker/containerd sweep:
-// list with labels, filter by label equality, skip known, then stop+delete the
-// rest. The base image is an OCI image (not a container), so it never appears in
-// `container list` and needs no special exclusion.
+// BuildProfileImage builds a profile's Dockerfile via `container build`,
+// following the shape planned in docs/contributors/design/plans/apple-container-backend.md
+// ("reuses the existing Dockerfile/profile images unchanged"). Like
+// buildBaseImage, the context is materialized into an absolute temp dir —
+// `container build .` silently drops a relative context (AC1) — reusing the
+// same profile-directory filtering (skip the checksum marker and
+// config.yaml) the docker backend uses for its tar context.
+//
+// container build has no documented --secret plumbing (unlike the docker
+// backend's BuildKit invocation), so any auto-detected build secrets (e.g. an
+// ~/.npmrc) are reported and dropped rather than silently ignored or failing
+// the build outright.
+func (r *Runtime) BuildProfileImage(ctx context.Context, sourceDir string, tag string, secrets []string, buildEnv config.Layout, output io.Writer, logger *slog.Logger) error {
+	if len(secrets) > 0 {
+		fmt.Fprintf(output, "Warning: build secrets are not supported on the apple backend; %d secret(s) will not be available to the build\n", len(secrets)) //nolint:errcheck // best-effort progress
+	}
+
+	dir, err := buildEnv.MkdirTemp("yoloai-apple-profile-build-")
+	if err != nil {
+		return fmt.Errorf("create build dir: %w", err)
+	}
+	defer os.RemoveAll(dir) //nolint:errcheck // best-effort temp cleanup
+
+	if err := dockerrt.WriteProfileBuildContextDir(sourceDir, dir); err != nil {
+		return fmt.Errorf("write profile build context: %w", err)
+	}
+	logger.Debug("building profile image via container build", "tag", tag, "sourceDir", sourceDir, "context", dir)
+
+	cmd := sysexec.CommandContext(ctx, r.execEnv, r.containerBin, "build", "-t", tag, dir)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("container build: %w", err)
+	}
+	return nil
+}
+
+// ProfileImageNeedsBuild reports whether the profile image is stale. Delegates
+// to the docker backend's checksum scheme, keyed to apple's own store (DF150).
+func (r *Runtime) ProfileImageNeedsBuild(profileDir string, parentDir string) bool {
+	return dockerrt.ProfileImageNeedsBuild(profileDir, parentDir, "apple")
+}
+
+// RecordProfileBuildChecksum records the profile's Dockerfile checksum after a
+// successful build. Delegates to the docker backend's checksum scheme, keyed
+// to apple's own store (DF150).
+func (r *Runtime) RecordProfileBuildChecksum(profileDir string) {
+	dockerrt.RecordProfileBuildChecksum(profileDir, "apple")
+}
+
+// Prune sweeps orphaned apple containers — `yoloai-*` instances (scoped to this
+// runtime's principal) that no longer correspond to a known sandbox. Mirrors the
+// tart/docker sweep: list, filter to this principal's prefix, skip known, then
+// stop+delete the rest. The base image is an OCI image (not a container), so it
+// never appears in `container list` and needs no special exclusion.
 func (r *Runtime) Prune(ctx context.Context, knownInstances []string, dryRun bool, output io.Writer) (runtime.PruneResult, error) {
 	out, err := r.runContainer(ctx, "list", "--all", "--format", "json")
 	if err != nil {

--- a/runtime/apple/apple.go
+++ b/runtime/apple/apple.go
@@ -28,7 +28,7 @@ import (
 // minMacOSMajor is the lowest macOS major version we allow. Apple `container`
 // technically runs on macOS 15 with limitations (no container-to-container net,
 // no `container network`, IP conflicts), so we gate strictly on 26 (Tahoe) as a
-// safe over-gate. See docs/contributors/design/plans/apple-container-backend.md (AC14).
+// safe over-gate. See docs/contributors/archive/plans/apple-container-backend.md (AC14).
 const minMacOSMajor = 26
 
 // containerBin is the CLI we shell out to.
@@ -131,6 +131,7 @@ type Runtime struct {
 var _ runtime.Backend = (*Runtime)(nil)
 var _ runtime.InteractiveSession = (*Runtime)(nil)
 var _ runtime.GitExecer = (*Runtime)(nil)
+var _ runtime.ProfileImageBuilder = (*Runtime)(nil)
 
 // New constructs the apple Runtime after verifying platform, the CLI, and the
 // macOS version gate. The apiserver is not started here — Setup does that on
@@ -473,7 +474,7 @@ func (r *Runtime) buildBaseImage(ctx context.Context, layout config.Layout, outp
 }
 
 // BuildProfileImage builds a profile's Dockerfile via `container build`,
-// following the shape planned in docs/contributors/design/plans/apple-container-backend.md
+// following the shape planned in docs/contributors/archive/plans/apple-container-backend.md
 // ("reuses the existing Dockerfile/profile images unchanged"). Like
 // buildBaseImage, the context is materialized into an absolute temp dir —
 // `container build .` silently drops a relative context (AC1) — reusing the

--- a/runtime/apple/apple.go
+++ b/runtime/apple/apple.go
@@ -502,10 +502,18 @@ func (r *Runtime) BuildProfileImage(ctx context.Context, sourceDir string, tag s
 	logger.Debug("building profile image via container build", "tag", tag, "sourceDir", sourceDir, "context", dir)
 
 	cmd := sysexec.CommandContext(ctx, buildEnv.Env().EnvForAppleContainer(), r.containerBin, "build", "-t", tag, dir)
-	cmd.Stdout = output
-	cmd.Stderr = output
+	// Stream to output as before, but also tee into a tail buffer so a failure's
+	// actionable cause rides on the error itself, not only the (maybe discarded)
+	// stream — same value on both so os/exec keeps its single-pipe path (DF145).
+	tail := sysexec.NewTailBuffer(buildErrorTailLines)
+	w := io.MultiWriter(output, tail)
+	cmd.Stdout = w
+	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("container build: %w", err)
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+			return fmt.Errorf("container build exited with code %d%s", exitErr.ExitCode(), tail.ErrorSuffix())
+		}
+		return fmt.Errorf("container build: %w%s", err, tail.ErrorSuffix())
 	}
 	return nil
 }

--- a/runtime/apple/build_test.go
+++ b/runtime/apple/build_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,4 +38,69 @@ func TestBuildBaseImage_ErrorCarriesOutputTail(t *testing.T) {
 		"the error names the operation and exit code")
 	assert.Contains(t, err.Error(), cause,
 		"the build tool's own diagnostic rides on the error, not only the stream (DF144/DF145)")
+}
+
+// newFakeContainerRuntime builds a Runtime whose containerBin runs script
+// (a full shell script body, shebang included) instead of the real `container`
+// CLI, mirroring TestBuildBaseImage_ErrorCarriesOutputTail's fixture pattern.
+func newFakeContainerRuntime(t *testing.T, script string) *Runtime {
+	t.Helper()
+	dir := t.TempDir()
+	fakeBin := filepath.Join(dir, "container")
+	require.NoError(t, os.WriteFile(fakeBin, []byte(script), 0700)) //nolint:gosec // test fixture needs exec bit
+
+	return &Runtime{
+		containerBin: fakeBin,
+		layout:       config.NewLayout(filepath.Join(t.TempDir(), ".yoloai")).WithPrincipal(config.CLIPrincipal),
+		execEnv:      []string{"PATH=/usr/bin:/bin"},
+	}
+}
+
+// newFakeProfileDir writes a minimal profile directory containing just a
+// Dockerfile — the only file createProfileBuildContext requires to build a
+// tar context (config.yaml and the checksum marker are filtered out, not
+// required in).
+func newFakeProfileDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM yoloai-base\n"), 0600))
+	return dir
+}
+
+func TestBuildProfileImage_ErrorWrapsExitStatus(t *testing.T) {
+	const cause = "ERROR: failed to solve: process did not complete successfully"
+	script := "#!/bin/sh\necho '" + cause + "' >&2\nexit 1\n"
+	r := newFakeContainerRuntime(t, script)
+	sourceDir := newFakeProfileDir(t)
+
+	var output strings.Builder
+	err := r.BuildProfileImage(context.Background(), sourceDir, "yoloai-r-dev", nil, r.layout, &output, slog.New(slog.DiscardHandler))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "container build:",
+		"the error names the failed operation")
+	assert.Contains(t, output.String(), cause,
+		"the build tool's own diagnostic still reaches the caller's output stream, even though "+
+			"(unlike buildBaseImage) BuildProfileImage does not also fold it onto the error itself")
+}
+
+func TestBuildProfileImage_WarnsOnDroppedSecrets(t *testing.T) {
+	r := newFakeContainerRuntime(t, "#!/bin/sh\nexit 0\n")
+	sourceDir := newFakeProfileDir(t)
+
+	var output strings.Builder
+	err := r.BuildProfileImage(context.Background(), sourceDir, "yoloai-r-dev", []string{"npmrc"}, r.layout, &output, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	assert.Contains(t, output.String(), "not supported on the apple backend",
+		"an auto-detected build secret must be reported, not silently dropped")
+	assert.Contains(t, output.String(), "1 secret(s)")
+}
+
+func TestBuildProfileImage_NoWarningWithoutSecrets(t *testing.T) {
+	r := newFakeContainerRuntime(t, "#!/bin/sh\nexit 0\n")
+	sourceDir := newFakeProfileDir(t)
+
+	var output strings.Builder
+	err := r.BuildProfileImage(context.Background(), sourceDir, "yoloai-r-dev", nil, r.layout, &output, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	assert.Empty(t, output.String(), "no secrets means no warning noise")
 }

--- a/runtime/apple/build_test.go
+++ b/runtime/apple/build_test.go
@@ -74,7 +74,7 @@ func TestBuildProfileImage_ErrorWrapsExitStatus(t *testing.T) {
 	sourceDir := newFakeProfileDir(t)
 
 	var output strings.Builder
-	err := r.BuildProfileImage(context.Background(), sourceDir, "yoloai-r-dev", nil, r.layout, &output, slog.New(slog.DiscardHandler))
+	err := r.BuildProfileImage(context.Background(), sourceDir, "yoloai-cli-dev", nil, r.layout, &output, slog.New(slog.DiscardHandler))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "container build exited with code 1",
 		"the error names the operation and exit code")
@@ -87,7 +87,7 @@ func TestBuildProfileImage_WarnsOnDroppedSecrets(t *testing.T) {
 	sourceDir := newFakeProfileDir(t)
 
 	var output strings.Builder
-	err := r.BuildProfileImage(context.Background(), sourceDir, "yoloai-r-dev", []string{"npmrc"}, r.layout, &output, slog.New(slog.DiscardHandler))
+	err := r.BuildProfileImage(context.Background(), sourceDir, "yoloai-cli-dev", []string{"npmrc"}, r.layout, &output, slog.New(slog.DiscardHandler))
 	require.NoError(t, err)
 	assert.Contains(t, output.String(), "not supported on the apple backend",
 		"an auto-detected build secret must be reported, not silently dropped")
@@ -99,7 +99,7 @@ func TestBuildProfileImage_NoWarningWithoutSecrets(t *testing.T) {
 	sourceDir := newFakeProfileDir(t)
 
 	var output strings.Builder
-	err := r.BuildProfileImage(context.Background(), sourceDir, "yoloai-r-dev", nil, r.layout, &output, slog.New(slog.DiscardHandler))
+	err := r.BuildProfileImage(context.Background(), sourceDir, "yoloai-cli-dev", nil, r.layout, &output, slog.New(slog.DiscardHandler))
 	require.NoError(t, err)
 	assert.Empty(t, output.String(), "no secrets means no warning noise")
 }

--- a/runtime/apple/build_test.go
+++ b/runtime/apple/build_test.go
@@ -82,6 +82,31 @@ func TestBuildProfileImage_ErrorWrapsExitStatus(t *testing.T) {
 		"the build tool's own diagnostic rides on the error, not only the stream (DF144/DF145)")
 }
 
+// TestBuildProfileImage_PassesTagAndAbsoluteContext pins the argv this fix
+// depends on (D128): `-t <tag>` must be passed, and the build context must be
+// an absolute directory containing the profile's Dockerfile. A relative
+// context (AC1) silently transfers nothing and every COPY fails — a defect
+// no assertion on the wrapped error alone would catch.
+func TestBuildProfileImage_PassesTagAndAbsoluteContext(t *testing.T) {
+	const tag = "yoloai-cli-dev"
+	script := "#!/bin/sh\n" +
+		"[ \"$1\" = build ] || { echo \"bad subcommand: $1\" >&2; exit 2; }\n" +
+		"[ \"$2\" = -t ] || { echo \"bad flag: $2\" >&2; exit 3; }\n" +
+		"[ \"$3\" = " + tag + " ] || { echo \"bad tag: $3\" >&2; exit 4; }\n" +
+		"case \"$4\" in\n" +
+		"  /*) ;;\n" +
+		"  *) echo \"context not absolute: $4\" >&2; exit 5 ;;\n" +
+		"esac\n" +
+		"test -f \"$4/Dockerfile\" || { echo \"Dockerfile missing from context\" >&2; exit 6; }\n" +
+		"exit 0\n"
+	r := newFakeContainerRuntime(t, script)
+	sourceDir := newFakeProfileDir(t)
+
+	var output strings.Builder
+	err := r.BuildProfileImage(context.Background(), sourceDir, tag, nil, r.layout, &output, slog.New(slog.DiscardHandler))
+	require.NoError(t, err, output.String())
+}
+
 func TestBuildProfileImage_WarnsOnDroppedSecrets(t *testing.T) {
 	r := newFakeContainerRuntime(t, "#!/bin/sh\nexit 0\n")
 	sourceDir := newFakeProfileDir(t)

--- a/runtime/apple/build_test.go
+++ b/runtime/apple/build_test.go
@@ -76,11 +76,10 @@ func TestBuildProfileImage_ErrorWrapsExitStatus(t *testing.T) {
 	var output strings.Builder
 	err := r.BuildProfileImage(context.Background(), sourceDir, "yoloai-r-dev", nil, r.layout, &output, slog.New(slog.DiscardHandler))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "container build:",
-		"the error names the failed operation")
-	assert.Contains(t, output.String(), cause,
-		"the build tool's own diagnostic still reaches the caller's output stream, even though "+
-			"(unlike buildBaseImage) BuildProfileImage does not also fold it onto the error itself")
+	assert.Contains(t, err.Error(), "container build exited with code 1",
+		"the error names the operation and exit code")
+	assert.Contains(t, err.Error(), cause,
+		"the build tool's own diagnostic rides on the error, not only the stream (DF144/DF145)")
 }
 
 func TestBuildProfileImage_WarnsOnDroppedSecrets(t *testing.T) {

--- a/runtime/apple/build_test.go
+++ b/runtime/apple/build_test.go
@@ -57,9 +57,11 @@ func newFakeContainerRuntime(t *testing.T, script string) *Runtime {
 }
 
 // newFakeProfileDir writes a minimal profile directory containing just a
-// Dockerfile — the only file createProfileBuildContext requires to build a
-// tar context (config.yaml and the checksum marker are filtered out, not
-// required in).
+// Dockerfile — the only file BuildProfileImage needs in order to materialize a
+// build context, which on this path is a *directory* written by
+// dockerrt.WriteProfileBuildContextDir rather than the tar the docker backend
+// streams. config.yaml and the per-backend checksum markers are filtered out of
+// that context, so they are not required in.
 func newFakeProfileDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -104,6 +106,29 @@ func TestBuildProfileImage_PassesTagAndAbsoluteContext(t *testing.T) {
 
 	var output strings.Builder
 	err := r.BuildProfileImage(context.Background(), sourceDir, tag, nil, r.layout, &output, slog.New(slog.DiscardHandler))
+	require.NoError(t, err, output.String())
+}
+
+// TestBuildProfileImage_DrawsEnvFromBuildEnvNotTheRuntime pins the other half
+// of the ProfileImageBuilder contract (rule 10): buildEnv is the environment
+// the build subprocess draws from, not the execEnv captured when the Runtime
+// was constructed. The two are the same in the single-principal CLI, which is
+// why using the wrong one is invisible there — it separates only for an
+// embedder that builds profiles for more than one principal, and that is
+// exactly the caller the contract exists for.
+//
+// The fake binary fails loudly if it sees the Runtime's env, so this test
+// fails when the fix is reverted rather than merely covering the line.
+func TestBuildProfileImage_DrawsEnvFromBuildEnvNotTheRuntime(t *testing.T) {
+	script := "#!/bin/sh\n" +
+		"[ -z \"$YOLOAI_RUNTIME_ENV_LEAKED\" ] || { echo 'build ran under r.execEnv, not buildEnv' >&2; exit 7; }\n" +
+		"exit 0\n"
+	r := newFakeContainerRuntime(t, script)
+	r.execEnv = []string{"YOLOAI_RUNTIME_ENV_LEAKED=1"}
+	sourceDir := newFakeProfileDir(t)
+
+	var output strings.Builder
+	err := r.BuildProfileImage(context.Background(), sourceDir, "yoloai-cli-dev", nil, r.layout, &output, slog.New(slog.DiscardHandler))
 	require.NoError(t, err, output.String())
 }
 

--- a/runtime/docker/build.go
+++ b/runtime/docker/build.go
@@ -233,6 +233,25 @@ func WriteBuildContextDir(dir string) error {
 	if err != nil {
 		return err
 	}
+	return writeTarToDir(tarReader, dir)
+}
+
+// WriteProfileBuildContextDir materializes a profile's build context (its
+// Dockerfile and sibling files, excluding the internal checksum marker and
+// config.yaml — same filtering as createProfileBuildContext) into dir.
+// Backends whose build command needs a *directory* context rather than a
+// stdin tar — e.g. Apple `container build <dir>` — use this instead of the
+// tar-based profile build context.
+func WriteProfileBuildContextDir(sourceDir string, dir string) error {
+	tarReader, err := createProfileBuildContext(sourceDir)
+	if err != nil {
+		return err
+	}
+	return writeTarToDir(tarReader, dir)
+}
+
+// writeTarToDir unpacks a tar stream into dir, one file per entry.
+func writeTarToDir(tarReader io.Reader, dir string) error {
 	tr := tar.NewReader(tarReader)
 	for {
 		hdr, err := tr.Next()


### PR DESCRIPTION
Thanks for sharing this.  I am running on apple silicon and need customized Dockerfiles (data science projects).  I discovered that the apple container backend wasn't building these when they were being provided in `~/.yoloai/library/profiles/<profile_name>/Dockerfile` and fixed this.